### PR TITLE
64-bit Compatibility

### DIFF
--- a/yajl/yajl_common.py
+++ b/yajl/yajl_common.py
@@ -48,3 +48,13 @@ def get_yajl_version():
     return '%s.%s.%s' %tuple(map(int, [v[:-4], v[-4:-2], v[-2:]]))
 
 yajl = load_yajl()
+
+yajl.yajl_alloc.restype = c_void_p
+yajl.yajl_alloc.argtypes = [c_void_p, c_void_p, c_void_p, c_void_p]
+yajl.yajl_free.argtypes = [c_void_p]
+yajl.yajl_parse.restype = c_int
+yajl.yajl_parse.argtypes = [c_void_p, c_char_p, c_int]
+yajl.yajl_parse_complete.restype = c_int
+yajl.yajl_parse_complete.argtypes = [c_void_p]
+yajl.yajl_get_error.restype = c_char_p
+yajl.yajl_get_error.argtypes = [c_void_p, c_int, c_char_p, c_int]


### PR DESCRIPTION
Hi,

I ran into some problems using yajl-py with a 64-bit Linux host. The problem turned out to be an issue with ctypes. It assumes, by default, that C functions return a c_int. The yajl.yajl_alloc function returns a pointer, however. On a 64-bit machine this causes the high 32 bits of the pointer to be discarded, leading to seg faults when the address was larger than 2^32. I went ahead and added restype and argtypes for all the functions used in yajl_parse.py. I have tested this on a 64-bit host, and it is working fine so far, but I cannot claim to have exhaustively tested it, so caveat emptor :)

CG.
