### PR TITLE
get everything working with flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 80
+ignore = F403

--- a/tests/test_yajl.py
+++ b/tests/test_yajl.py
@@ -3,29 +3,42 @@ from minimocktest import MockTestCase
 from StringIO import StringIO
 import sys
 
+
 class BaseContentHandler(yajl.YajlContentHandler):
+
     def yajl_null(self, ctx):
         pass
+
     def yajl_boolean(self, ctx, boolVal):
         pass
+
     def yajl_integer(self, ctx, integerVal):
         pass
+
     def yajl_double(self, ctx, doubleVal):
         pass
+
 #     def yajl_number(self, ctx, stringNum):
 #         pass
+
     def yajl_string(self, ctx, stringVal):
         pass
+
     def yajl_start_map(self, ctx):
         pass
+
     def yajl_map_key(self, ctx, stringVal):
         pass
+
     def yajl_end_map(self, ctx):
         pass
+
     def yajl_start_array(self, ctx):
         pass
+
     def yajl_end_array(self, ctx):
         pass
+
 
 class YajlParserTests(MockTestCase):
     '''
@@ -72,10 +85,10 @@ class YajlParserTests(MockTestCase):
 
     def test_allCallbacksExceptNumber(self):
         for func in [
-            'null', 'boolean', 'integer', 'double', 'string',
-            'start_map', 'map_key', 'end_map',
-            'start_array', 'end_array']:
-            self.mock('self.content_handler.yajl_%s' %(func))
+                'null', 'boolean', 'integer', 'double', 'string',
+                'start_map', 'map_key', 'end_map',
+                'start_array', 'end_array']:
+            self.mock('self.content_handler.yajl_%s' % (func))
         parser = yajl.YajlParser(self.content_handler)
         parser.parse(self.basic_json)
         self.assertSameTrace(
@@ -92,22 +105,22 @@ class YajlParserTests(MockTestCase):
         )
 
     def test_largestNumberAcceptableInIntegerCallback(self):
-        good_json = StringIO('[%s]' %(sys.maxint))
-        bad_json = StringIO('[%s]' %(sys.maxint+1))
+        good_json = StringIO('[%s]' % (sys.maxint))
+        bad_json = StringIO('[%s]' % (sys.maxint + 1))
         self.mock('self.content_handler.yajl_integer')
         parser = yajl.YajlParser(self.content_handler)
         parser.parse(good_json)
         self.assertSameTrace(
-            "Called self.content_handler.yajl_integer(None, %s)\n" %sys.maxint
+            "Called self.content_handler.yajl_integer(None, %s)\n" % sys.maxint
         )
         self.assertRaises(yajl.YajlError, parser.parse, bad_json)
 
     def test_ctxIsPassedToAllCallbacks(self):
         for func in [
-            'null', 'boolean', 'integer', 'double', 'string',
-            'start_map', 'map_key', 'end_map',
-            'start_array', 'end_array']:
-            self.mock('self.content_handler.yajl_%s' %(func))
+                'null', 'boolean', 'integer', 'double', 'string',
+                'start_map', 'map_key', 'end_map',
+                'start_array', 'end_array']:
+            self.mock('self.content_handler.yajl_%s' % (func))
         parser = yajl.YajlParser(self.content_handler)
         ctx = yajl.create_string_buffer('TEST')
         parser.parse(self.basic_json, ctx=yajl.byref(ctx))
@@ -141,6 +154,7 @@ class YajlParserTests(MockTestCase):
         self.assertRaises(
             yajl.YajlError,
             parser.parse, invalid_json)
+
 
 class YajlGenTests(MockTestCase):
     '''
@@ -216,6 +230,7 @@ class YajlGenTests(MockTestCase):
             '}\n',
             ''.join(results))
 
+
 class YajlCommonTests(MockTestCase):
     '''
     Testing common functions and the loading libyajl
@@ -236,11 +251,10 @@ class YajlCommonTests(MockTestCase):
                     yajl_version = major * 10000 + minor * 100 + micro
                     self.mock('yajl.yajl.yajl_version', returns=yajl_version)
                     self.assertEqual(
-                        '%s.%s.%s' %(major, minor, micro),
+                        '%s.%s.%s' % (major, minor, micro),
                         yajl.get_yajl_version())
 
     def test_check_yajl_version_warnsOnlyWhenMismatchedVersions(self):
-        import warnings
         self.mock('warnings.warn')
         self.mock('yajl.wrapped.__version__', mock_obj='1.1.1')
         self.mock('yajl.wrapped.yajl_version', mock_obj='1.1.1')
@@ -250,9 +264,9 @@ class YajlCommonTests(MockTestCase):
         self.assertFalse(yajl.check_yajl_version())
         self.assertSameTrace(
             "Called warnings.warn("
-                "'Using Yajl-Py v1.1.1 with Yajl v1.1.0. "
-                "It is advised to use the same Yajl-Py and Yajl versions',"
-                "<type 'exceptions.RuntimeWarning'>, stacklevel=3)"
+            "'Using Yajl-Py v1.1.1 with Yajl v1.1.0. "
+            "It is advised to use the same Yajl-Py and Yajl versions',"
+            "<type 'exceptions.RuntimeWarning'>, stacklevel=3)"
         )
 
     def test_checkYajlPyAndYajlHaveSameVersion(self):

--- a/tests/test_yajl_c.py
+++ b/tests/test_yajl_c.py
@@ -1,34 +1,47 @@
-from yajl_test_lib import yajl, BASEPATH 
+from yajl_test_lib import yajl, BASEPATH
 from minimocktest import MockTestCase
 from StringIO import StringIO
 import os
-import difflib
+
 
 class YajlCTestContentHandler(yajl.YajlContentHandler):
+
     def __init__(self):
         self.out = StringIO()
+
     def yajl_null(self, ctx):
-        self.out.write("null\n" )
+        self.out.write("null\n")
+
     def yajl_boolean(self, ctx, boolVal):
-        self.out.write("bool: %s\n" %('true' if boolVal else 'false'))
+        self.out.write("bool: %s\n" % ('true' if boolVal else 'false'))
+
     def yajl_integer(self, ctx, integerVal):
-        self.out.write("integer: %s\n" %integerVal)
+        self.out.write("integer: %s\n" % integerVal)
+
     def yajl_double(self, ctx, doubleVal):
-        self.out.write("double: %s\n" %doubleVal)
+        self.out.write("double: %s\n" % doubleVal)
+
 #     def yajl_number(self, ctx, stringNum):
 #         pass
+
     def yajl_string(self, ctx, stringVal):
-        self.out.write("string: '%s'\n" %stringVal)
+        self.out.write("string: '%s'\n" % stringVal)
+
     def yajl_start_map(self, ctx):
         self.out.write("map open '{'\n")
+
     def yajl_map_key(self, ctx, stringVal):
-        self.out.write("key: '%s'\n" %stringVal)
+        self.out.write("key: '%s'\n" % stringVal)
+
     def yajl_end_map(self, ctx):
         self.out.write("map close '}'\n")
+
     def yajl_start_array(self, ctx):
         self.out.write("array open '['\n")
+
     def yajl_end_array(self, ctx):
         self.out.write("array close ']'\n")
+
 
 class YajlCTests(MockTestCase):
     '''
@@ -42,7 +55,7 @@ class YajlCTests(MockTestCase):
         self.out = self.content_handler.out
 
     def assertSameAsGold(self, filename):
-        with open('%s.gold' %filename) as f:
+        with open('%s.gold' % filename) as f:
             expected = f.read()
         # we currently do not test for memory leaks
         expected = expected.replace('memory leaks:\t0\n', '')
@@ -53,6 +66,7 @@ class YajlCTests(MockTestCase):
     def resetOutput(self):
         self.out.seek(0)
         self.out.truncate()
+
 
 def _make_test(filename, testname):
     def test(self):
@@ -75,10 +89,11 @@ def _make_test(filename, testname):
                 try:
                     parser.parse(f)
                 except yajl.YajlError, e:
-                    self.out.write('%s\n' %str(e).splitlines()[0])
+                    self.out.write('%s\n' % str(e).splitlines()[0])
             self.assertSameAsGold(filename)
             self.resetOutput()
     return test
+
 
 def _add_methods():
     dirpath = os.path.join(BASEPATH, 'cases')
@@ -87,6 +102,6 @@ def _add_methods():
         fullname = os.path.join(dirpath, filename)
         name = filename[:-5]
         test = _make_test(fullname, name)
-        setattr(YajlCTests, 'test_%s' %name, test)
+        setattr(YajlCTests, 'test_%s' % name, test)
 
 _add_methods()

--- a/tests/yajl_test_lib.py
+++ b/tests/yajl_test_lib.py
@@ -4,9 +4,4 @@ Helper module to import yajl from parent src dir
 import os
 import sys
 BASEPATH = os.path.dirname(os.path.realpath(__file__))
-sys.path = [BASEPATH, '%s/..' %BASEPATH] + sys.path
-
-import yajl
-import unittest
-from minimocktest import MockTestCase
-from StringIO import StringIO
+sys.path = [BASEPATH, '%s/..' % BASEPATH] + sys.path

--- a/yajl/__init__.py
+++ b/yajl/__init__.py
@@ -14,8 +14,10 @@ from yajl_common import *
 from yajl_parse import *
 from yajl_gen import *
 
+
 __version__ = '2.1.1'
 yajl_version = get_yajl_version()
+
 
 def check_yajl_version():
     '''
@@ -28,22 +30,27 @@ def check_yajl_version():
         import warnings
         warnings.warn(
             'Using Yajl-Py v%s with Yajl v%s. '
-            'It is advised to use the same Yajl-Py and Yajl versions' %(
+            'It is advised to use the same Yajl-Py and Yajl versions' % (
                 __version__, yajl_version),
             RuntimeWarning, stacklevel=3)
         return False
     return True
 
+
 check_yajl_version()
+
 
 # monkey patch yajl, because anyjson devs are slacking off,
 # and I got an issue request that I would like to help out.
 class Wrapper(object):
-  def __init__(self, wrapped):
-    self.wrapped = wrapped
-  def __getattr__(self, name):
-    if name in ('dumps', 'loads'):
-        raise ImportError('this is not py-yajl ... anyjson!')
-    return getattr(self.wrapped, name)
+
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+
+        def __getattr__(self, name):
+            if name in ('dumps', 'loads'):
+                raise ImportError('this is not py-yajl ... anyjson!')
+            return getattr(self.wrapped, name)
+
 
 sys.modules[__name__] = Wrapper(sys.modules[__name__])

--- a/yajl/yajl_common.py
+++ b/yajl/yajl_common.py
@@ -9,17 +9,23 @@ Common functions and members used by yajl-py (parse and gen)
 
 from ctypes import *
 
+
 class YajlException(Exception):
     pass
+
 
 class YajlConfigError(YajlException):
     pass
 
+
 class YajlError(YajlException):
+
     def __init__(self, value=''):
         self.value = value
+
     def __str__(self):
         return self.value
+
 
 def load_yajl():
     '''
@@ -30,13 +36,15 @@ def load_yajl():
     :raises OSError: when libyajl cannot be loaded
     '''
     for ftype in '', '.so', '.dylib':
-        yajlso = 'libyajl%s' %(ftype)
+        yajlso = 'libyajl%s' % (ftype)
         try:
             return cdll.LoadLibrary(yajlso)
         except OSError:
             pass
-    raise OSError('Yajl shared object cannot be found. '
+    raise OSError(
+        'Yajl shared object cannot be found. '
         'Please install Yajl and confirm it is on your shared lib path.')
+
 
 def get_yajl_version():
     '''
@@ -45,8 +53,8 @@ def get_yajl_version():
     :rtype: string
     :returns: yajl's version in the format 'Major.Minor.Micro'
     '''
-    v = '%0.6d' %yajl.yajl_version()
-    return '%s.%s.%s' %tuple(map(int, [v[:-4], v[-4:-2], v[-2:]]))
+    v = '%0.6d' % yajl.yajl_version()
+    return '%s.%s.%s' % tuple(map(int, [v[:-4], v[-4:-2], v[-2:]]))
 
 yajl = load_yajl()
 
@@ -66,6 +74,7 @@ yajl.yajl_get_bytes_consumed.restype = c_size_t
 yajl.yajl_get_bytes_consumed.argtypes = [c_void_p]
 yajl.yajl_free_error.restype = None
 yajl.yajl_free_error.argtypes = [c_void_p, c_char_p]
+
 # Yajl Gen
 yajl.yajl_gen_config.argtypes = [c_void_p, c_int]
 yajl.yajl_gen_alloc.restype = c_void_p

--- a/yajl/yajl_gen.py
+++ b/yajl/yajl_gen.py
@@ -18,15 +18,17 @@ yajl_gen_status = {
 yajl_gen_status_ok = 0
 
 (
-yajl_gen_beautify,
-yajl_gen_indent_string,
-yajl_gen_print_callback,
-yajl_gen_validate_utf8,
-yajl_gen_escape_solidus,
-) = map(c_int, [2**x for x in range(5)])
+    yajl_gen_beautify,
+    yajl_gen_indent_string,
+    yajl_gen_print_callback,
+    yajl_gen_validate_utf8,
+    yajl_gen_escape_solidus,
+) = map(c_int, [2 ** x for x in range(5)])
+
 
 class YajlGenException(YajlError):
     pass
+
 
 class YajlGen(object):
     '''
@@ -54,13 +56,15 @@ class YajlGen(object):
             ('validate_utf8', yajl_gen_validate_utf8),
             ('gen_escape_solidus', yajl_gen_escape_solidus),
         ])
-        for k,v in kwargs.items():
+        for k, v in kwargs.items():
             self._yajl_gen('yajl_gen_config', config_map[k], v)
 
     def __del__(self):
         self._yajl_gen('yajl_gen_free')
+
     def yajl_gen_reset(self, sep=''):
         self._yajl_gen('yajl_gen_reset', sep)
+
     def _assert_retval(self, retval):
         '''
         :param retval: yajl_gen_status return code
@@ -69,6 +73,7 @@ class YajlGen(object):
         '''
         if retval != yajl_gen_status_ok:
             raise YajlGenException(yajl_gen_status[retval])
+
     def yajl_gen_get_buf(self):
         '''
         :returns: Formatted JSON
@@ -87,12 +92,14 @@ class YajlGen(object):
             return string_at(buf, l.value)
         finally:
             self._yajl_gen('yajl_gen_clear')
+
     def _yajl_gen(self, name, *args):
         '''
         Call the underlying yajl_gen c function/method
         ``self.g`` must be already allocated
         '''
         return getattr(yajl, name)(self.g, *args)
+
     def _dispatch(self, name, *args):
         '''
         :param name: yajl func ``name`` to dispatch to
@@ -103,30 +110,33 @@ class YajlGen(object):
         Asserts that the returned value is proper or raises the proper
         ``YajlGenException``
         '''
-        self._assert_retval(
-            self._yajl_gen(name, *args)
-        )
+        self._assert_retval(self._yajl_gen(name, *args))
+
     def yajl_gen_null(self):
         ''' Generate json value ``null`` '''
         self._dispatch('yajl_gen_null')
+
     def yajl_gen_bool(self, b):
         '''
         :param b: flag to be jsonified
         :type b: bool
         '''
         self._dispatch('yajl_gen_bool', b)
+
     def yajl_gen_integer(self, n):
         '''
         :param n: number to be jsonified
         :type n: int
         '''
         self._dispatch('yajl_gen_integer', c_longlong(n))
+
     def yajl_gen_double(self, n):
         '''
         :param n: number to be jsonified
         :type n: float
         '''
         self._dispatch('yajl_gen_double', c_double(n))
+
     def yajl_gen_number(self, s):
         '''
         :param s: number to be jsonified
@@ -136,21 +146,26 @@ class YajlGen(object):
         or :meth:`yajl_gen_integer` respectively.
         '''
         self._dispatch('yajl_gen_number', c_char_p(s), len(s))
+
     def yajl_gen_string(self, s):
         '''
         :param s: string to be jsonified
         :type s: string
         '''
         self._dispatch('yajl_gen_string', c_char_p(s), len(s))
+
     def yajl_gen_map_open(self):
         ''' indicate json map begin '''
         self._dispatch('yajl_gen_map_open')
+
     def yajl_gen_map_close(self):
         ''' indicate json map close '''
         self._dispatch('yajl_gen_map_close')
+
     def yajl_gen_array_open(self):
         ''' indicate json array begin '''
         self._dispatch('yajl_gen_array_open')
+
     def yajl_gen_array_close(self):
         ''' indicate json array close '''
         self._dispatch('yajl_gen_array_close')

--- a/yajl/yajl_parse.py
+++ b/yajl/yajl_parse.py
@@ -9,49 +9,54 @@ from abc import ABCMeta, abstractmethod
 # Callback Functions
 YAJL_NULL = CFUNCTYPE(c_int, c_void_p)
 YAJL_BOOL = CFUNCTYPE(c_int, c_void_p, c_int)
-YAJL_INT  = CFUNCTYPE(c_int, c_void_p, c_longlong)
-YAJL_DBL  = CFUNCTYPE(c_int, c_void_p, c_double)
-YAJL_NUM  = CFUNCTYPE(c_int, c_void_p, POINTER(c_ubyte), c_uint)
-YAJL_STR  = CFUNCTYPE(c_int, c_void_p, POINTER(c_ubyte), c_uint)
+YAJL_INT = CFUNCTYPE(c_int, c_void_p, c_longlong)
+YAJL_DBL = CFUNCTYPE(c_int, c_void_p, c_double)
+YAJL_NUM = CFUNCTYPE(c_int, c_void_p, POINTER(c_ubyte), c_uint)
+YAJL_STR = CFUNCTYPE(c_int, c_void_p, POINTER(c_ubyte), c_uint)
 YAJL_SDCT = CFUNCTYPE(c_int, c_void_p)
 YAJL_DCTK = CFUNCTYPE(c_int, c_void_p, POINTER(c_ubyte), c_uint)
 YAJL_EDCT = CFUNCTYPE(c_int, c_void_p)
 YAJL_SARR = CFUNCTYPE(c_int, c_void_p)
 YAJL_EARR = CFUNCTYPE(c_int, c_void_p)
+
+
 class yajl_callbacks(Structure):
     _fields_ = [
-        ("yajl_null",           YAJL_NULL),
-        ("yajl_boolean",        YAJL_BOOL),
-        ("yajl_integer",        YAJL_INT ),
-        ("yajl_double",         YAJL_DBL ),
-        ("yajl_number",         YAJL_NUM ),
-        ("yajl_string",         YAJL_STR ),
-        ("yajl_start_map",      YAJL_SDCT),
-        ("yajl_map_key",        YAJL_DCTK),
-        ("yajl_end_map",        YAJL_EDCT),
-        ("yajl_start_array",    YAJL_SARR),
-        ("yajl_end_array",      YAJL_EARR),
+        ("yajl_null", YAJL_NULL),
+        ("yajl_boolean", YAJL_BOOL),
+        ("yajl_integer", YAJL_INT),
+        ("yajl_double", YAJL_DBL),
+        ("yajl_number", YAJL_NUM),
+        ("yajl_string", YAJL_STR),
+        ("yajl_start_map", YAJL_SDCT),
+        ("yajl_map_key", YAJL_DCTK),
+        ("yajl_end_map", YAJL_EDCT),
+        ("yajl_start_array", YAJL_SARR),
+        ("yajl_end_array", YAJL_EARR),
     ]
 
 # yajl option
 (
-yajl_allow_comments,
-yajl_dont_validate_strings,
-yajl_allow_trailing_garbage,
-yajl_allow_multiple_values,
-yajl_allow_partial_values
-) = map(c_int, [2**x for x in range(5)])
+    yajl_allow_comments,
+    yajl_dont_validate_strings,
+    yajl_allow_trailing_garbage,
+    yajl_allow_multiple_values,
+    yajl_allow_partial_values
+) = map(c_int, [2 ** x for x in range(5)])
 
 # yajl_status
 (
-yajl_status_ok,
-yajl_status_client_canceled,
-yajl_status_error
+    yajl_status_ok,
+    yajl_status_client_canceled,
+    yajl_status_error
 ) = map(c_int, range(3))
 
+
 class YajlParseCancelled(YajlError):
+
     def __init__(self):
         self.value = 'Client Callback Cancelled Parse'
+
 
 class YajlContentHandler(object):
     '''
@@ -79,46 +84,62 @@ class YajlContentHandler(object):
     this is a yajl feature that is implemented in yajl-py but not very useful
     in python.  see :meth:`YajlParser.parse` for more info on :obj:`ctx`.
     '''
+
     __metaclass__ = ABCMeta
+
     @abstractmethod
     def yajl_null(self, ctx):
         pass
+
     @abstractmethod
     def yajl_boolean(self, ctx, boolVal):
         pass
+
 #     @abstractmethod
 #     def yajl_integer(self, ctx, integerVal):
 #         pass
+#
 #     @abstractmethod
 #     def yajl_double(self, ctx, doubleVal):
 #         pass
+#
 #     @abstractmethod
 #     def yajl_number(self, ctx, stringVal):
 #         pass
+
     @abstractmethod
     def yajl_string(self, ctx, stringVal):
         pass
+
     @abstractmethod
     def yajl_start_map(self, ctx):
         pass
+
     @abstractmethod
     def yajl_map_key(self, ctx, stringVal):
         pass
+
     @abstractmethod
     def yajl_end_map(self, ctx):
         pass
+
     @abstractmethod
     def yajl_start_array(self, ctx):
         pass
+
     @abstractmethod
     def yajl_end_array(self, ctx):
         pass
+
     def parse_start(self):
         ''' Called before each stream is parsed '''
+
     def parse_buf(self):
         ''' Called when a complete buffer has been parsed from the stream '''
+
     def complete_parse(self):
         ''' Called when the parsing of the stream has finished '''
+
 
 class YajlParser(object):
     '''
@@ -135,8 +156,8 @@ class YajlParser(object):
 
         To configure the parser you need to set attributes. Attribute
         names are similar to that of yajl names less the "yajl_" prefix,
-        for example: 
-            to enable yajl_allow_comments, set self.allow_comments=True 
+        for example:
+            to enable yajl_allow_comments, set self.allow_comments=True
         '''
         # input validation
         if buf_siz <= 0:
@@ -146,33 +167,48 @@ class YajlParser(object):
             YAJL_STR, YAJL_SDCT, YAJL_DCTK, YAJL_EDCT, YAJL_SARR,
             YAJL_EARR
         )
+
         def yajl_null(ctx):
             return dispatch('yajl_null', ctx)
+
         def yajl_boolean(ctx, boolVal):
             return dispatch('yajl_boolean', ctx, boolVal)
+
         def yajl_integer(ctx, integerVal):
             return dispatch('yajl_integer', ctx, integerVal)
+
         def yajl_double(ctx, doubleVal):
+
             return dispatch('yajl_double', ctx, doubleVal)
+
         def yajl_number(ctx, stringVal, stringLen):
             return dispatch('yajl_number', ctx, string_at(stringVal, stringLen))
+
         def yajl_string(ctx, stringVal, stringLen):
+
             return dispatch('yajl_string', ctx, string_at(stringVal, stringLen))
+
         def yajl_start_map(ctx):
             return dispatch('yajl_start_map', ctx)
+
         def yajl_map_key(ctx, stringVal, stringLen):
-            return dispatch('yajl_map_key', ctx, string_at(stringVal, stringLen))
+            return dispatch('yajl_map_key', ctx, string_at(
+                stringVal, stringLen))
+
         def yajl_end_map(ctx):
             return dispatch('yajl_end_map', ctx)
+
         def yajl_start_array(ctx):
             return dispatch('yajl_start_array', ctx)
+
         def yajl_end_array(ctx):
             return dispatch('yajl_end_array', ctx)
+
         def dispatch(func, *args, **kwargs):
             try:
                 getattr(self.content_handler, func)(*args, **kwargs)
                 return 1
-            except Exception,e:
+            except Exception:
                 self._exc_info = sys.exc_info()
                 return 0
 
@@ -203,7 +239,7 @@ class YajlParser(object):
         self.content_handler = content_handler
 
     def yajl_config(self, hand):
-        for k,v in [
+        for k, v in [
             (yajl_allow_comments, 'allow_comments'),
             (yajl_dont_validate_strings, 'dont_validate_strings'),
             (yajl_allow_comments, 'allow_comments'),
@@ -239,13 +275,13 @@ class YajlParser(object):
                     stat = yajl.yajl_parse(hand, fileData, len(fileData))
                 if self.content_handler:
                     self.content_handler.parse_buf()
-                if  stat != yajl_status_ok.value:
+                if stat != yajl_status_ok.value:
                     if stat == yajl_status_client_canceled.value:
                         # it means we have an exception
                         if self._exc_info:
                             exc_info = self._exc_info
                             raise exc_info[0], exc_info[1], exc_info[2]
-                        else: # for some reason we have no error stored
+                        else:  # for some reason we have no error stored
                             raise YajlParseCancelled()
                     else:
                         yajl.yajl_get_error.restype = c_char_p


### PR DESCRIPTION
Mostly whitespace changes to appease flake8. flake8 now passes when run against both the `yajl/` directory and `tests` directory.

No logic changes in this diff.