### PR TITLE
Add compatability with Windows `yajl.dll`

### DIFF
--- a/yajl/yajl_common.py
+++ b/yajl/yajl_common.py
@@ -38,6 +38,13 @@ def load_yajl():
             return cdll.LoadLibrary(yajlso)
         except OSError:
             pass
+
+    yajlso = 'yajl.dll'
+    try:
+        return cdll.LoadLibrary(yajlso)
+    except OSError:
+        pass
+
     raise OSError('Yajl shared object cannot be found. '
         'Please install Yajl and confirm it is on your shared lib path.')
 

--- a/yajl/yajl_common.py
+++ b/yajl/yajl_common.py
@@ -32,18 +32,13 @@ def load_yajl():
     :returns: The yajl shared object
     :raises OSError: when libyajl cannot be loaded
     '''
-    for ftype in '', '.so', '.dylib':
-        yajlso = 'libyajl%s' %(ftype)
+    fnames = ['libyajl%s' %(t) for t in ['', '.so', '.dylib']] + ['yajl.dll']
+
+    for yajlso in fnames:
         try:
             return cdll.LoadLibrary(yajlso)
         except OSError:
             pass
-
-    yajlso = 'yajl.dll'
-    try:
-        return cdll.LoadLibrary(yajlso)
-    except OSError:
-        pass
 
     raise OSError('Yajl shared object cannot be found. '
         'Please install Yajl and confirm it is on your shared lib path.')


### PR DESCRIPTION
When building Yajl with the default build settings on Windows the resultant library is `yajl.dll`. I added an attempt to load this in load_yajl, then did a little refactoring to reduce code duplication.

I did the addition and the refactoring in separate commits, so I'm happy to resubmit this pull request without the refactor if you don't like it.

Passes all tests on Linux (Debian). Doesn't pass tests on Windows but only due to line ending differences. I can get almost all to pass by playing with the encoding when loading the `.gold` cases (except some with unusual characters such as `escaped_bulgarian.json.gold`).