### PR TITLE
Make tests run on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,17 @@ though it can be coded in such a way to make the encoding configurable, the
 decision has been made to keep with the decision made by ctypes and hence put
 the onus on the developer to decode/encode the input/output as necessary.
 
+Test Manually
+-------------
+
+To run tests manually, install ``mock``, ``nose`` and ``nose-cov`` from pip::
+
+    pip install -r test_requirements.txt
+
+and run::
+
+    python -m nose --with-cov --cover-erase --cov yajl -v tests/
+
 Contributions
 -------------
 

--- a/tests/test_yajl_c.py
+++ b/tests/test_yajl_c.py
@@ -45,6 +45,8 @@ class YajlCTests(unittest.TestCase):
         with open('%s.gold' %filename, 'rb') as f:
             expected = f.read()
         # we currently do not test for memory leaks
+        if os.name == 'nt':
+            expected = b'\n'.join(expected.split(b'\r\n'))
         expected = expected.replace(b'memory leaks:\t0\n', b'')
         self.out.seek(0)
         got = self.out.read()


### PR DESCRIPTION
Make tests run on windows by:
* Replacing `\r\n` with `\n` (because git might pull files and automatically correnct the line endings on Windows, and read file in binary mode on Windows would result in reading `\r\n` as seperate characters.
* Adding a manual test instruction in README